### PR TITLE
Set constants out of compiler flag to compile against LiteCoin

### DIFF
--- a/include/bitcoin/bitcoin/constants.hpp
+++ b/include/bitcoin/bitcoin/constants.hpp
@@ -302,11 +302,6 @@ BC_CONSTEXPR size_t testnet_bip65_freeze = 581885;
 BC_CONSTEXPR size_t testnet_bip66_freeze = 330776;
 BC_CONSTEXPR size_t testnet_bip34_freeze = 21111;
 
-// Regtest (arbitrary) frozen activation heights (frozen_activations).
-BC_CONSTEXPR size_t regtest_bip65_freeze = 1351;
-BC_CONSTEXPR size_t regtest_bip66_freeze = 1251;
-BC_CONSTEXPR size_t regtest_bip34_freeze = 0;
-
 // Block 514 is the first testnet block after date-based activation.
 // Block 166832 is the first mainnet block after date-based activation.
 BC_CONSTEXPR uint32_t bip16_activation_time = 0x4f3af580;
@@ -326,7 +321,12 @@ static const config::checkpoint mainnet_bip30_exception_checkpoint2 {
     "00000000000743f190a18c5577a3c2d2a1f610ae9601ac046a38084ccb7cd721", 91880
 };
 
-// bip90 stops checking unspent duplicates above this bip34 activation.
+#endif //BITPRIM_CURRENCY_LTC
+// Regtest (arbitrary) frozen activation heights (frozen_activations).
+BC_CONSTEXPR size_t regtest_bip65_freeze = 1351;
+BC_CONSTEXPR size_t regtest_bip66_freeze = 1251;
+BC_CONSTEXPR size_t regtest_bip34_freeze = 0;
+
 static const config::checkpoint mainnet_bip34_active_checkpoint {
     "000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8", 227931
 };
@@ -334,13 +334,12 @@ static const config::checkpoint mainnet_bip34_active_checkpoint {
 static const config::checkpoint testnet_bip34_active_checkpoint {
     "0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8", 21111
 };
+
 static const config::checkpoint regtest_bip34_active_checkpoint
 {
     // Since bip90 assumes a historical bip34 activation block, use genesis.
     "06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f", 0
 };
-
-#endif //BITPRIM_CURRENCY_LTC
 
 // These cannot be reactivated in a future branch due to window expiration.
 static const config::checkpoint mainnet_bip9_bit0_active_checkpoint {

--- a/src/chain/chain_state.cpp
+++ b/src/chain/chain_state.cpp
@@ -730,7 +730,7 @@ uint32_t chain_state::work_required_retarget(data const& values) {
 
     // return target > pow_limit ? pow_limit.compact() : target.compact();
 
-    return target > pow_limit ? proof_of_work_limit : compact(target).normal();
+    return target > pow_limit ? retarget_proof_of_work_limit : compact(target).normal();
 
 
 #else //BITPRIM_CURRENCY_LTC


### PR DESCRIPTION
Because of these constants be out of #ifdef BITPRIM_CURRENCY_LTC conan install could not compile against LTC.

https://files.slack.com/files-pri/T1ULE05NW-FB1TV85BN/litecoin-problem.png