### PR TITLE
BCH regtest configuration

### DIFF
--- a/src/chain/chain_state.cpp
+++ b/src/chain/chain_state.cpp
@@ -461,6 +461,13 @@ size_t chain_state::uahf_height(size_t height, uint32_t forks) {
 inline 
 size_t chain_state::daa_height(size_t height, uint32_t forks) {
     auto const testnet = script::is_enabled(forks, rule_fork::easy_blocks);
+    const auto retarget = script::is_enabled(forks, rule_fork::retarget);
+    const auto mainnet = retarget && !testnet;
+
+    if (!mainnet && !testnet) {
+        // Regtest activate at block 0
+        return true;
+    }
 
     auto const activation_height = testnet ? testnet_daa_active_checkpoint.height() : mainnet_daa_active_checkpoint.height();
 
@@ -471,6 +478,13 @@ size_t chain_state::daa_height(size_t height, uint32_t forks) {
 inline 
 bool chain_state::is_uahf_enabled(size_t height, uint32_t forks) {
     auto const testnet = script::is_enabled(forks, rule_fork::easy_blocks);
+    const auto retarget = script::is_enabled(forks, rule_fork::retarget);
+    const auto mainnet = retarget && !testnet;
+
+    if (!mainnet && !testnet) {
+        // Regtest activate at block 0
+        return true;
+    }
 
     auto const activation_height = testnet ? testnet_uahf_active_checkpoint.height() : mainnet_uahf_active_checkpoint.height();
 
@@ -480,6 +494,13 @@ bool chain_state::is_uahf_enabled(size_t height, uint32_t forks) {
 inline 
 bool chain_state::is_daa_enabled(size_t height, uint32_t forks) {
     auto const testnet = script::is_enabled(forks, rule_fork::easy_blocks);
+    const auto retarget = script::is_enabled(forks, rule_fork::retarget);
+    const auto mainnet = retarget && !testnet;
+
+    if (!mainnet && !testnet) {
+        // Regtest activate at block 0
+        return true;
+    }
 
     auto const activation_height = testnet ? testnet_daa_active_checkpoint.height() : mainnet_daa_active_checkpoint.height();
 


### PR DESCRIPTION
Activate BCH hardforks on block 0 so regtest can represent the current state of the mainnet chain